### PR TITLE
extractBodyFrom

### DIFF
--- a/src/Services/Message/Mail.php
+++ b/src/Services/Message/Mail.php
@@ -17,8 +17,8 @@ use Illuminate\Support\Collection;
 class Mail extends GmailConnection
 {
 	use HasDecodableBody,
-		Modifiable,
-		Replyable {
+	Modifiable,
+	Replyable {
 		Replyable::__construct as private __rConstruct;
 		Modifiable::__construct as private __mConstruct;
 	}
@@ -85,6 +85,7 @@ class Mail extends GmailConnection
 			$this->size = $message->getSizeEstimate();
 			$this->threatId = $message->getThreadId();
 			$this->payload = $message->getPayload();
+			
 		}
 	}
 
@@ -348,8 +349,8 @@ class Mail extends GmailConnection
 	 */
 	private function getBodyPart( $type = 'text/plain' )
 	{
-
 		$body = $this->payload->getParts();
+
 
 		if ( $this->hasAttachments() ) {
 			//Get the first attachment that is the main body
@@ -456,6 +457,96 @@ class Mail extends GmailConnection
 		$this->setToken($token);
 
 		return $this;
+	}
+
+
+
+	/* added by buckfuddey */
+
+	public function hasNoParts(){
+		if (empty($this->payload->getParts())) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+
+	public function extractFromBody(){
+
+		if ($this->hasNoParts()) {
+			$type = $this->payload->getMimeType();
+			$body = $this->payload->getBody();
+			if ($type == 'text/html' || $type == 'text/plain') {
+				$this->bodyArr[$type] = $this->getDecodedBody($body->getData());
+			}
+			if ($body->getAttachmentId()) {
+				$this->attachmentData[] = array(
+					'id' => $body->getAttachmentId(),
+					'fileName' => $part->getFilename(),
+					'mimeType' => $type
+				);
+			}
+		} else {
+			$parts = $this->payload->getParts();
+			foreach ($parts as $part) {
+				if (empty($part->getParts())) {
+					$type = $part->getMimeType();
+					$body = $part->getBody();
+					if ($type == 'text/html' || $type == 'text/plain') {
+						if (isset($this->messageBodyArr[$type])) {
+							$this->messageBodyArr[$type] .= $this->getDecodedBody($body->getData());
+						} else {
+							$this->messageBodyArr[$type] = $this->getDecodedBody($body->getData());
+						}
+					}
+
+					if ($body->getAttachmentId()) {
+						$this->attachmentData[] = array(
+							'id' => $body->getAttachmentId(),
+							'fileName'  => $part->getFilename(),
+							'mimeType' => $type
+						);						
+					}				
+				} else {
+					$subParts = $part->getParts();
+					$this->traverseData($subParts);
+				}
+			}
+		}		
+	}
+
+	public function traverseData($parts){
+		foreach ($parts as $part) {			
+			if (empty($part->getParts())) {
+				$type = $part->getMimeType();
+				$body = $part->getBody();
+				if ($type == 'text/html' || $type == 'text/plain') {
+					if (isset($this->messageBodyArr[$type])) {
+						$this->messageBodyArr[$type] .= $this->getDecodedBody($body->getData());
+					} else {
+						$this->messageBodyArr[$type] = $this->getDecodedBody($body->getData());
+					}						
+				}
+
+				if ($body->getAttachmentId()) {
+					$this->attachmentData[] = array(
+						'id' => $body->getAttachmentId(),
+						'fileName'  => $part->getFilename(),
+						'mimeType' => $type
+					);
+
+				}
+			} else {
+				$subParts = $part->getParts();
+				$this->traverseData($subParts);
+			}
+		}
+	}
+
+	public function getDecodedBody( $content ) {
+		$content = str_replace( '_', '/', str_replace( '-', '+', $content ) );
+		return base64_decode( $content );
 	}
 
 }


### PR DESCRIPTION
This is an optional method that I have found works great for extracting the body of a message. It does not change any of your existing code. You simply call $message->extractBodyFrom . This was written by buckfuddey.  See issue #30   It has worked reliably for me in production for 2 days now.   Admittedly not the style you have, but it works to patch up some of the holes that keep creating this error. I propose you add it for now until at which point later you can clean it up, if you wish.