### PR TITLE
Get the correct size variable

### DIFF
--- a/src/Services/Message/Attachment.php
+++ b/src/Services/Message/Attachment.php
@@ -55,7 +55,7 @@ class Attachment extends GmailConnection
 
 		$body = $part->getBody();
 		$this->id = $body->getAttachmentId();
-		$this->size = $body->getAttachmentId();
+		$this->size = $body->getSize();
 		$this->filename = $part->getFilename();
 		$this->mimeType = $part->getMimeType();
 		$this->messageId = $singleMessageId;


### PR DESCRIPTION
The size variable was incorrectly set to 
`$body->getAttachmentId()`
insted of:
`$body->getSize()`