### PR TITLE
Support for additional Google Scopes

### DIFF
--- a/src/Traits/Configurable.php
+++ b/src/Traits/Configurable.php
@@ -54,12 +54,19 @@ trait Configurable
 		];
 	}
 
+	private function additionalGoogleScopes() {
+
+		$googleScopes[] = '';
+		return $googleScopes;
+	}
+
 	private function getUserScopes()
 	{
+
 		return array_merge(
 			[
 				Google_Service_Gmail::GMAIL_READONLY,
-			], $this->mapScopes() );
+			], $this->mapScopes(), $this->additionalGoogleScopes() );
 	}
 
 	private function configApi()


### PR DESCRIPTION
Hi Man,

Thank you so much for your repository. Saved me lots of time (so much, that I've even decided to help you with your beer budget  LOL). Anyhow, I think it will be great if you add this PR as it allows to get additional Google scopes with one OAuth request. Without it - the app will have to do multiple OAuth requests to get additional scopes. For instance: if you want to get in addition to the email address the user's first and last name you'll have to do another OAuth 3-legged request after getting the gmail scopes.