### PR TITLE
Typo and duplicate property fixes

### DIFF
--- a/src/Services/Message/Mail.php
+++ b/src/Services/Message/Mail.php
@@ -46,7 +46,7 @@ class Mail extends GmailConnection
 	/**
 	 * @var
 	 */
-	public $threatId;
+	public $threadId;
 
 	/**
 	 * @var \Google_Service_Gmail_MessagePart
@@ -90,7 +90,7 @@ class Mail extends GmailConnection
 		$this->internalDate = $message->getInternalDate();
 		$this->labels = $message->getLabelIds();
 		$this->size = $message->getSizeEstimate();
-		$this->threatId = $message->getThreadId();
+		$this->threadId = $message->getThreadId();
 		$this->payload = $message->getPayload();
 	}
 
@@ -126,13 +126,13 @@ class Mail extends GmailConnection
 	}
 
 	/**
-	 * Returns threat ID of the email
+	 * Returns thread ID of the email
 	 *
 	 * @return string
 	 */
-	public function getThreatId()
+	public function getThreadId()
 	{
-		return $this->threatId;
+		return $this->threadId;
 	}
 
 	/**

--- a/src/Traits/Modifiable.php
+++ b/src/Traits/Modifiable.php
@@ -15,8 +15,6 @@ trait Modifiable
 		ModifiesLabels::__construct as private __mlConstruct;
 	}
 
-	private $messageRequest;
-
 	public function __construct()
 	{
 		/** @scrutinizer ignore-call */

--- a/src/Traits/ModifiesLabels.php
+++ b/src/Traits/ModifiesLabels.php
@@ -8,7 +8,6 @@ use Google_Service_Gmail_ModifyMessageRequest;
 trait ModifiesLabels
 {
 
-	public $service;
 	private $messageRequest;
 
 	public function __construct()

--- a/src/Traits/Replyable.php
+++ b/src/Traits/Replyable.php
@@ -291,27 +291,27 @@ trait Replyable
 			throw new \Exception('This is a new email. Use send().');
 		}
 
-		$this->setReplyThreat();
+		$this->setReplyThread();
 		$this->setReplySubject();
 		$body = $this->getMessageBody();
-		$body->setThreadId($this->getThreatId());
+		$body->setThreadId($this->getThreadId());
 
 		return new Mail($this->service->users_messages->send('me', $body, $this->parameters));
 	}
 
 	public abstract function getId();
 
-	private function setReplyThreat()
+	private function setReplyThread()
 	{
-		$threatId = $this->getThreatId();
-		if ($threatId) {
+		$threadId = $this->getThreadId();
+		if ($threadId) {
 			$this->setHeader('In-Reply-To', $this->getHeader('In-Reply-To'));
 			$this->setHeader('References', $this->getHeader('References'));
 			$this->setHeader('Message-ID', $this->getHeader('Message-ID'));
 		}
 	}
 
-	public abstract function getThreatId();
+	public abstract function getThreadId();
 
 	/**
 	 * Add a header to the email

--- a/src/Traits/SendsParameters.php
+++ b/src/Traits/SendsParameters.php
@@ -5,10 +5,8 @@ namespace Dacastro4\LaravelGmail\Traits;
 trait SendsParameters
 {
 
-	protected $params = [];
-
 	/**
-	 * Ads parameters to the parameters property which is used to send additional parameter in the request.
+	 * Adds parameters to the parameters property which is used to send additional parameters in the request.
 	 *
 	 * @param $query
 	 * @param  string  $column


### PR DESCRIPTION
A few properties are declared multiple times across classes and traits. The unnecessary duplication causes some exceptions to be thrown. The properties have been removed where it makes the most sense to ensure continued functionality.

Several places `thread` is referenced in the code which should be properly spelled `thread`. This has been fixed throughout the codebase.