### PR TITLE
$attachment->headerDetails['X-Attachment-Id'] added

### DIFF
--- a/src/Services/Message/Attachment.php
+++ b/src/Services/Message/Attachment.php
@@ -31,6 +31,14 @@ class Attachment extends GmailConnection
 	 * @var
 	 */
 	public $size;
+    /**
+     * @var
+     */
+    public $headerDetails;
+    /**
+     * @var
+     */
+    private $headers;
 	/**
 	 * @var Google_Service_Gmail
 	 */
@@ -59,6 +67,8 @@ class Attachment extends GmailConnection
 		$this->filename = $part->getFilename();
 		$this->mimeType = $part->getMimeType();
 		$this->messageId = $singleMessageId;
+        $headers = $part->getHeaders();
+        $this->headerDetails = $this->getHeaderDetails($headers);
 	}
 
 	/**
@@ -146,4 +156,19 @@ class Attachment extends GmailConnection
 
 		return $attachment->getData();
 	}
+
+	/**
+     * Returns attachment headers
+     * Contains Content-ID and X-Attachment-Id for embedded images
+     *
+     * @return array
+     */
+    public function getHeaderDetails($headers)
+    {
+        $headerDetails = [];
+        foreach ($headers as $header){
+            $headerDetails[$header->name] = $header->value;
+        }
+        return $headerDetails;
+    }
 }


### PR DESCRIPTION
Emails which have embedded images, use as placeholder the X-Attachment-Id which is always in the header of the attachment part.
It would be nice to have something like:
$xAttachmentId = $attachment->headerDetails['X-Attachment-Id'];
Because otherwise its not possible to connect the image data with the embedded image.