### PR TITLE
Update a list of supported PHP versions (support PHP 8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 8.0
 
 install: travis_retry composer install --no-interaction --prefer-source
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.3|^8.0",
     "google/apiclient": "^2.5",
     "illuminate/auth": "~5.8|^6.0|^7.0|^8.0",
     "illuminate/config": "~5.8|^6.0|^7.0|^8.0",
@@ -26,10 +26,10 @@
     "swiftmailer/swiftmailer": "~5.8|^6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^8.5|^9.0",
     "mockery/mockery": "^1.0",
     "squizlabs/php_codesniffer": "~3.4",
-    "orchestra/testbench": "^4.0"
+    "orchestra/testbench": "^4.0|^5.0|^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ if you need **Laravel 7** compatibility please use version `4.0.x`.
 
 # Requirements
 
-* \>= PHP 7.3 <= PHP 7.4
+* \>= PHP 7.3 <= PHP 8.0
 * Laravel 8
 
 # Installation


### PR DESCRIPTION
PHP 7.2 is EOL: https://www.php.net/supported-versions.php

Minimum supported version is 7.3 (critical security issues only.)

Closes #174 