### PR TITLE
PHP 8.0 bug - method must be compatible with trait's abstract declaration

### DIFF
--- a/src/Traits/Replyable.php
+++ b/src/Traits/Replyable.php
@@ -407,5 +407,5 @@ trait Replyable
 		return $this;
 	}
 
-	protected abstract function setMessage($message);
+	protected abstract function setMessage(\Google_Service_Gmail_Message $message);
 }


### PR DESCRIPTION
In PHP 8.0 I'm getting a fatal error:

```
ERROR: Declaration of Dacastro4\LaravelGmail\Services\Message\Mail::setMessage(Google_Service_Gmail_Message $message) must be compatible with Dacastro4\LaravelGmail\Traits\Replyable::setMessage($message)
```

This fixes that.