### PR TITLE
Read messages & attachments while allow multiple credentials

### DIFF
--- a/src/Services/Message.php
+++ b/src/Services/Message.php
@@ -77,7 +77,7 @@ class Message
 
 		if (!$this->preload) {
 			foreach ($allMessages as $message) {
-				$messages[] = new Mail($message, $this->preload);
+				$messages[] = new Mail($message, $this->preload, $this->client->userId);
 			}
 		} else {
 			$messages = $this->batchRequest($allMessages);
@@ -121,7 +121,7 @@ class Message
 	{
 		$message = $this->getRequest($id);
 
-		return new Mail($message);
+		return new Mail($message, false, $this->client->userId);
 	}
 
 	/**
@@ -148,7 +148,7 @@ class Message
 		$messages = [];
 
 		foreach ($messagesBatch as $message) {
-			$messages[] = new Mail($message);
+			$messages[] = new Mail($message, false, $this->client->userId);
 		}
 
 		return $messages;

--- a/src/Services/Message/Attachment.php
+++ b/src/Services/Message/Attachment.php
@@ -55,10 +55,12 @@ class Attachment extends GmailConnection
 	 *
 	 * @param $singleMessageId
 	 * @param  \Google_Service_Gmail_MessagePart  $part
+	 * @param  \Google_Service_Gmail_MessagePart  $part
+	 * @param  int 	$userId
 	 */
-	public function __construct($singleMessageId, \Google_Service_Gmail_MessagePart $part)
+	public function __construct($singleMessageId, \Google_Service_Gmail_MessagePart $part, $userId = null)
 	{
-		parent::__construct(config());
+		parent::__construct(config(), $userId);
 
 		$this->service = new Google_Service_Gmail($this);
 

--- a/src/Services/Message/Mail.php
+++ b/src/Services/Message/Mail.php
@@ -37,6 +37,11 @@ class Mail extends GmailConnection
 	/**
 	 * @var
 	 */
+	public $userId;
+
+	/**
+	 * @var
+	 */
 	public $internalDate;
 
 	/**
@@ -86,12 +91,24 @@ class Mail extends GmailConnection
 				$message = $this->service->users_messages->get('me', $message->getId());
 			}
 
+			$this->setUserId($userId);
+
 			$this->setMessage($message);
 
 			if ($preload) {
 				$this->setMetadata();
 			}
 		}
+	}
+
+	/**
+	 * Set user Id
+	 *
+	 * @param int $userId
+	 */
+	protected function setUserId($userId)
+	{
+		$this->userId = $userId;
 	}
 
 	/**
@@ -497,7 +514,7 @@ class Mail extends GmailConnection
 
 		foreach ($parts as $part) {
 			if (!empty($part->body->attachmentId)) {
-				$attachment = (new Attachment($part->body->attachmentId, $part));
+				$attachment = (new Attachment($part->body->attachmentId, $part, $this->userId));
 
 				if ($preload) {
 					$attachment = $attachment->getData();


### PR DESCRIPTION
I have Auth error while fetching message when multiple credentials enabled, The problem is that userId not passed to "Dacastro4\LaravelGmail\Services\Message\Mail" class when create new instances from "Dacastro4\LaravelGmail\Service\Message" class.
Also same problem regarding to attachments. So I have just pass new parameter to Attachment Class and then pass to parent constructor.
