### PR TITLE
fix: allow preload() to work when there are no messages to preload

### DIFF
--- a/src/Services/Message.php
+++ b/src/Services/Message.php
@@ -80,7 +80,7 @@ class Message
 				$messages[] = new Mail($message, $this->preload, $this->client->userId);
 			}
 		} else {
-			$messages = $this->batchRequest($allMessages);
+			$messages = count($allMessages) > 0 ? $this->batchRequest($allMessages) : [];
 		}
 
 		$all = new MessageCollection($messages, $this);


### PR DESCRIPTION
When using `preload()` and there are no messages returned, an error is thrown. This change will only go to fetch the messages content if there are messages to fetch.