### PR TITLE
Update Replyable.php to fix threading when reply

### DIFF
--- a/src/Traits/Replyable.php
+++ b/src/Traits/Replyable.php
@@ -307,10 +307,20 @@ trait Replyable
 	{
 		$threadId = $this->getThreadId();
 		if ($threadId) {
-			$this->setHeader('In-Reply-To', $this->getHeader('In-Reply-To'));
+			$this->setHeader('In-Reply-To', $this->getMessageIdHeader());
 			$this->setHeader('References', $this->getHeader('References'));
-			$this->setHeader('Message-ID', $this->getHeader('Message-ID'));
+			$this->setHeader('Message-ID', $this->getMessageIdHeader());
 		}
+	}
+	
+	private function getMessageIdHeader() {
+		if($this->getHeader('Message-ID')) {
+			return $this->getHeader('Message-ID');
+		}
+		if($this->getHeader('Message-Id')) {
+			return $this->getHeader('Message-Id');
+		}
+		return null;
 	}
 
 	public abstract function getThreadId();


### PR DESCRIPTION
Hi
I have used your package to make a complete gmail mailbox. From my experience, some changes will make this repo even more better.

1. When a email has been replied, the emails are not grouped together as a thread in the receivers mailbox. This is because 'In-Reply-To' header should be set to 'Message-ID' header of the email that is being replied. Currently it is set to 'In-Reply-To' header of the parent email. so if that header exists, current reply is occuring on parent emails 'In-reply-To' message.  if that header does not exist, it creates a separate thread.

2. 'Message-ID' header is not consistent through all emails in gmail. But one of either 'Message-ID' or 'Message-Id' header is always present. So added a function to get consistent 'Message-ID' header.