### PR TITLE
feat: ability to add message body from a markdown file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -242,6 +242,8 @@ For `to`, `from`, `cc` and `bcc`, you can set an array of emails and name or a s
 
 `$mail->view( 'view.name', $dataArray )` sets the body from a blade file
 
+`$mail->markdown( 'view.name', $dataArray )` sets the body from a markdown file
+
 `$mail->attach( ...$path )` add file attachments to the email
 
 `$mail->priority( $priority )` sets the priority of the email from 1 to 5

--- a/src/Traits/Replyable.php
+++ b/src/Traits/Replyable.php
@@ -5,6 +5,8 @@ namespace Dacastro4\LaravelGmail\Traits;
 use Dacastro4\LaravelGmail\Services\Message\Mail;
 use Google_Service_Gmail;
 use Google_Service_Gmail_Message;
+use Illuminate\Container\Container;
+use Illuminate\Mail\Markdown;
 use Swift_Attachment;
 use Swift_Message;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
@@ -217,6 +219,25 @@ trait Replyable
 
 		return $this;
 	}
+
+    /**
+     * loads markdown file for message body
+     *
+     * @throws \Throwable
+     * @return Replyable
+     */
+    public function markdown(string $markdown_view, array $data = [])
+    {
+        $markdown = Container::getInstance()->make(Markdown::class);
+
+        if (config('mail.markdown.theme')) {
+            $markdown->theme(config('mail.markdown.theme'));
+        }
+
+        $this->message = $markdown->render($markdown_view, $data);
+
+        return $this;
+    }
 
 	/**
 	 * @param  string  $message

--- a/tests/LaravelGmailTest.php
+++ b/tests/LaravelGmailTest.php
@@ -1,8 +1,30 @@
 <?php
 
+use Dacastro4\LaravelGmail\Services\Message\Mail;
+use Illuminate\Container\Container;
+use Illuminate\Mail\Markdown;
 use Tests\TestCase;
 
 class LaravelGmailTest extends TestCase
 {
+    /** @test */
+    public function test_markdown_method()
+    {
+        // mocks
+        $mocked_markdown = Mockery::mock(Markdown::class);
+        Container::getInstance()->instance(Markdown::class, $mocked_markdown);
 
+        // expectations
+        $mocked_markdown->shouldReceive('theme')->once()->with(config('mail.markdown.theme'));
+        $mocked_markdown->shouldReceive('render')->once()->with(
+            'sample-markdown',
+            [ 'url' => 'https://www.google.com' ]
+        );
+        
+        // trigger
+        (new Mail())->markdown(
+            'sample-markdown', 
+            [ 'url' => 'https://www.google.com' ]
+        );
+    }
 }


### PR DESCRIPTION
❓laravel markdown mails are a lot cleaner than regular blade based mail and the existing **view** method cannot be used for the markdown files

This PR
✅ adds **markdown** method just like existing view **method** which basically does the same thing as laravel mailable markdown method
✅ adds unit test code for the **markdown** method
✅ updates **readme** for the new markdown method

