### PR TITLE
Laravel 10+: Fixes the issue: "An address can be an instance of Address or a strin…

### DIFF
--- a/src/Traits/Replyable.php
+++ b/src/Traits/Replyable.php
@@ -405,11 +405,17 @@ trait Replyable
 		$this->symfonyEmail
 			->from($this->fromAddress())
 			->to($this->toAddress())
-			->cc($this->returnCopies($this->cc))
-			->bcc($this->returnCopies($this->bcc))
 			->subject($this->subject)
 			->html($this->message)
 			->priority($this->priority);
+		
+		// Fixes the issue: "An address can be an instance of Address or a string ("null" given)."
+		if(isset($this->cc)){
+            $this->symfonyEmail->cc($this->returnCopies($this->cc));
+        }
+        if(isset($this->bcc)){
+            $this->symfonyEmail->bcc($this->returnCopies($this->bcc));
+        }
 
 		foreach ($this->attachments as $file) {
 			$this->symfonyEmail->attachFromPath($file);


### PR DESCRIPTION
…g ("null" given)."

Hello, I wasnt able to sent any emails at all due to an error in recent laravel update (or rather a symphony one) that doesnt allow the cc and bcc to be an empty array.

Pull request #267 almost fixes the issue, but he forgot to adjust the code so that bcc and cc is not used outside the if clausure.

Plus poor guy in ssue #266 never got an answer and he decided to give up.

Hope you can merge this one or tell the guy at #267 to fix his code then merge his. 

Thank you, your project is awesome, specially since digitalocean decided to kill all smtp servers back in 2022, this project allows us all to still send free emails from normal gmail accounts.
