### PR TITLE
Fix typo in Message service docblock

### DIFF
--- a/src/Services/Message.php
+++ b/src/Services/Message.php
@@ -96,16 +96,16 @@ class Message
 		return !!$this->pageToken;
 	}
 
-	/**
-	 * Limit the messages coming from the queryxw
-	 *
-	 * @param int $number
-	 *
-	 * @return Message
-	 */
-	public function take($number)
-	{
-		$this->params['maxResults'] = abs((int)$number);
+        /**
+         * Limit the messages coming from the query
+         *
+         * @param int $number
+         *
+         * @return Message
+         */
+        public function take($number)
+        {
+                $this->params['maxResults'] = abs((int)$number);
 
 		return $this;
 	}


### PR DESCRIPTION
## Summary
- fix typo in `Message::take` docblock

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689bc220c3c4832e92cc918e00630df8