### PR TITLE
docs: correct user method return type

### DIFF
--- a/src/LaravelGmailClass.php
+++ b/src/LaravelGmailClass.php
@@ -30,15 +30,15 @@ class LaravelGmailClass extends GmailConnection
 		return new Message($this);
 	}
 
-	/**
-	 * Returns the Gmail user email
-	 *
-	 * @return \Google_Service_Gmail_Profile
-	 */
-	public function user()
-	{
-		return $this->config('email');
-	}
+        /**
+         * Returns the Gmail user's email
+         *
+         * @return string
+         */
+        public function user()
+        {
+                return $this->config('email');
+        }
 
 	/**
 	 * Updates / sets the current userId for the service


### PR DESCRIPTION
## Summary
- fix user() docblock to return string

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689bc222079c832e8e4ea19d8d49ee57