### PR TITLE
Use sender name for nameFrom metadata

### DIFF
--- a/src/Services/Message/Mail.php
+++ b/src/Services/Message/Mail.php
@@ -143,7 +143,7 @@ class Mail extends GmailConnection
 		$this->to = $this->getTo();
 		$from = $this->getFrom();
 		$this->from = isset($from['email']) ? $from['email'] : null;
-		$this->nameFrom = isset($from['email']) ? $from['email'] : null;
+               $this->nameFrom = isset($from['name']) ? $from['name'] : null;
 
 		$this->subject = $this->getSubject();
 	}


### PR DESCRIPTION
## Summary
- fix `Mail::setMetadata` to store the sender's name in `nameFrom`

## Testing
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_689bc2222250832e8b5a54d674be86a0