### PR TITLE
Inject Request into GmailConnection::makeToken

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,7 @@ Route::get('/oauth/gmail', function (){
 });
 
 Route::get('/oauth/gmail/callback', function (){
-    LaravelGmail::makeToken();
+    LaravelGmail::makeToken(request());
     return redirect()->to('/');
 });
 
@@ -173,13 +173,13 @@ Generally speaking, it is a bad practice to use API for pagination. It is slow a
 
 `LaravelGmail::redirect` You can use this as a direct method `<a href="{{ LaravelGmail::redirect() }}">Login</a>`
 
-`LaravelGmail::makeToken()` Set and Save AccessToken in json file (useful in the callback)
+`LaravelGmail::makeToken($request)` Set and Save AccessToken in json file (useful in the callback)
 
 `LaravelGmail::logout` Logs out the user
 
 `LaravelGmail::check` Checks if the user is logged in
 
-`LaravelGmail::setUserId($account_id)->makeToken()` Set and Save AccessToken for $account_id (added v5.1.2)
+`LaravelGmail::setUserId($account_id)->makeToken($request)` Set and Save AccessToken for $account_id (added v5.1.2)
 
 
 ## Sending

--- a/src/GmailConnection.php
+++ b/src/GmailConnection.php
@@ -7,7 +7,7 @@ use Dacastro4\LaravelGmail\Traits\HasLabels;
 use Google_Client;
 use Google_Service_Gmail;
 use Illuminate\Container\Container;
-use Illuminate\Support\Facades\Request;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
 class GmailConnection extends Google_Client
@@ -180,10 +180,9 @@ class GmailConnection extends Google_Client
      *
      * @throws \Exception
      */
-    public function makeToken()
+    public function makeToken(Request $request)
     {
         if (! $this->check()) {
-            $request = Request::capture();
             $code = (string) $request->input('code', null);
             if (! is_null($code) && ! empty($code)) {
                 $accessToken = $this->fetchAccessTokenWithAuthCode($code);

--- a/tests/MakeTokenTest.php
+++ b/tests/MakeTokenTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Dacastro4\LaravelGmail\GmailConnection;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class MakeTokenTest extends TestCase
+{
+    /** @test */
+    public function make_token_uses_injected_request_code()
+    {
+        Storage::fake('local');
+
+        $config = [
+            'gmail.client_secret' => 'secret',
+            'gmail.client_id' => 'id',
+            'gmail.redirect_url' => '/callback',
+            'gmail.state' => null,
+            'gmail.scopes' => [],
+            'gmail.additional_scopes' => [],
+            'gmail.access_type' => 'offline',
+            'gmail.approval_prompt' => 'force',
+            'gmail.credentials_file_name' => 'gmail-json',
+            'gmail.allow_multiple_credentials' => false,
+            'gmail.allow_json_encrypt' => false,
+        ];
+
+        $connection = \Mockery::mock(GmailConnection::class.'[check,fetchAccessTokenWithAuthCode]', [$config]);
+        $connection->shouldReceive('check')->andReturn(false);
+        $connection->shouldReceive('fetchAccessTokenWithAuthCode')
+            ->with('test-code')
+            ->once()
+            ->andReturn(['access_token' => 'token']);
+
+        $request = Request::create('/callback', 'GET', ['code' => 'test-code']);
+
+        $this->assertEquals(
+            ['access_token' => 'token'],
+            $connection->makeToken($request)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- allow `GmailConnection::makeToken` to accept an `Illuminate\Http\Request`
- document new request parameter and update usage examples
- test that `makeToken` pulls the authorization code from the injected request

## Testing
- `vendor/bin/phpunit tests`
- `vendor/bin/pint`


------
https://chatgpt.com/codex/tasks/task_b_689bca1e227c832ea2ac3c8bbed15a27