### PR TITLE
Add PHPStan static analysis

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,20 @@
+name: Static Analysis
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse src tests

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,11 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3|^10.5",
-        "mockery/mockery": "^1.0",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^v4.18.0|^v5.20.0|^v6.25.0|^8.0|^9.0|^10.0"
+        "mockery/mockery": "^1.0",
+        "orchestra/testbench": "^v4.18.0|^v5.20.0|^v6.25.0|^8.0|^9.0|^10.0",
+        "phpstan/phpstan": "^1.0",
+        "phpunit/phpunit": "^9.3|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 7
+    paths:
+        - src
+        - tests


### PR DESCRIPTION
## Summary
- add PHPStan dev dependency and configuration
- run PHPStan in CI via GitHub Actions

## Testing
- `vendor/bin/phpstan analyse src tests --memory-limit=1G` *(fails: Found 220 errors)*
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_b_689bca1fbd54832e8efede8d741f9906