### PR TITLE
Refactor message service with typed properties

### DIFF
--- a/src/Services/Message.php
+++ b/src/Services/Message.php
@@ -8,26 +8,26 @@ use Dacastro4\LaravelGmail\Traits\Filterable;
 use Dacastro4\LaravelGmail\Traits\SendsParameters;
 use Google_Service_Gmail;
 use Google_Service_Gmail_ListMessagesResponse;
+use Google_Service_Gmail_Message;
+use Illuminate\Support\Collection;
 
 class Message
 {
     use Filterable,
         SendsParameters;
 
-    public $service;
+    private Google_Service_Gmail $service;
 
-    public $preload = false;
+    private bool $preload = false;
 
-    public $pageToken;
+    private ?string $pageToken = null;
 
-    public $client;
+    private LaravelGmailClass $client;
 
     /**
      * Optional parameter for getting single and multiple emails
-     *
-     * @var array
      */
-    protected $params = [];
+    protected array $params = [];
 
     /**
      * Message constructor.
@@ -41,28 +41,21 @@ class Message
     /**
      * Returns next page if available of messages or an empty collection
      *
-     * @return \Illuminate\Support\Collection
-     *
      * @throws \Google_Exception
      */
-    public function next()
+    public function next(): Collection
     {
-        if ($this->pageToken) {
-            return $this->all($this->pageToken);
-        } else {
-            return new MessageCollection([], $this);
-        }
+        return $this->pageToken
+            ? $this->all($this->pageToken)
+            : new MessageCollection([], $this);
     }
 
     /**
      * Returns a collection of Mail instances
      *
-     *
-     * @return \Illuminate\Support\Collection
-     *
      * @throws \Google_Exception
      */
-    public function all(?string $pageToken = null)
+    public function all(?string $pageToken = null): Collection
     {
         if (! is_null($pageToken)) {
             $this->add($pageToken, 'pageToken');
@@ -87,31 +80,28 @@ class Message
 
     /**
      * Returns boolean if the page token variable is null or not
-     *
-     * @return bool
      */
-    public function hasNextPage()
+    public function hasNextPage(): bool
     {
         return (bool) $this->pageToken;
     }
 
+    public function getPageToken(): ?string
+    {
+        return $this->pageToken;
+    }
+
     /**
      * Limit the messages coming from the query
-     *
-     * @param  int  $number
-     * @return Message
      */
-    public function take($number)
+    public function take(int $number): self
     {
-        $this->params['maxResults'] = abs((int) $number);
+        $this->params['maxResults'] = abs($number);
 
         return $this;
     }
 
-    /**
-     * @return Mail
-     */
-    public function get($id)
+    public function get(string $id): Mail
     {
         $message = $this->getRequest($id);
 
@@ -120,11 +110,8 @@ class Message
 
     /**
      * Creates a batch request to get all emails in a single call
-     *
-     *
-     * @return array|null
      */
-    public function batchRequest($allMessages)
+    public function batchRequest(array $allMessages): array
     {
         $this->client->setUseBatch(true);
 
@@ -151,26 +138,21 @@ class Message
      * Preload the information on each Mail objects.
      * If is not preload you will have to call the load method from the Mail class
      *
-     * @return $this
-     *
      * @see Mail::load()
      */
-    public function preload()
+    public function preload(): self
     {
         $this->preload = true;
 
         return $this;
     }
 
-    public function getUser()
+    public function getUser(): string
     {
         return $this->client->user();
     }
 
-    /**
-     * @return \Google_Service_Gmail_Message
-     */
-    private function getRequest($id)
+    private function getRequest(string $id): Google_Service_Gmail_Message
     {
         return $this->service->users_messages->get('me', $id);
     }

--- a/src/Services/MessageCollection.php
+++ b/src/Services/MessageCollection.php
@@ -6,10 +6,7 @@ use Illuminate\Support\Collection;
 
 class MessageCollection extends Collection
 {
-    /**
-     * @var Message
-     */
-    private $message;
+    private ?Message $message;
 
     /**
      * MessageCollection constructor.
@@ -22,28 +19,24 @@ class MessageCollection extends Collection
         $this->message = $message;
     }
 
-    public function next()
+    public function next(): Collection
     {
         return $this->message->next();
     }
 
     /**
      * Returns boolean if the page token variable is null or not
-     *
-     * @return bool
      */
-    public function hasNextPage()
+    public function hasNextPage(): bool
     {
-        return (bool) $this->message->pageToken;
+        return $this->message->hasNextPage();
     }
 
     /**
      * Returns the page token or null
-     *
-     * @return string
      */
-    public function getPageToken()
+    public function getPageToken(): ?string
     {
-        return $this->message->pageToken;
+        return $this->message->getPageToken();
     }
 }


### PR DESCRIPTION
## Summary
- add typed private properties and method return types for message service
- expose page token via getter and use it in MessageCollection

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_b_689bcf1c0d4c832eae67baee1ffe45db