### PR TITLE
Add tests for GmailConnection and Mail classes

### DIFF
--- a/tests/GmailConnectionTest.php
+++ b/tests/GmailConnectionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests;
+
+use Dacastro4\LaravelGmail\GmailConnection;
+use Illuminate\Support\Facades\Storage;
+
+class GmailConnectionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'gmail.client_secret' => 'secret',
+            'gmail.client_id' => 'client',
+            'gmail.redirect_url' => '/',
+            'gmail.credentials_file_name' => 'test-token',
+            'gmail.allow_json_encrypt' => false,
+            'gmail.allow_multiple_credentials' => false,
+        ]);
+    }
+
+    /** @test */
+    public function set_both_access_token_stores_and_sets_token()
+    {
+        Storage::fake('local');
+        $connection = new GmailConnection($this->app['config']);
+
+        $token = ['access_token' => 'token', 'refresh_token' => 'refresh'];
+        $connection->setBothAccessToken($token);
+
+        Storage::disk('local')->assertExists('gmail/tokens/test-token.json');
+        $this->assertSame($token, $connection->getAccessToken());
+    }
+
+    /** @test */
+    public function get_user_id_returns_value_passed_to_constructor()
+    {
+        $connection = new GmailConnection($this->app['config'], 'user-123');
+
+        $this->assertEquals('user-123', $connection->getUserId());
+    }
+}

--- a/tests/LaravelGmailClassTest.php
+++ b/tests/LaravelGmailClassTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests;
+
+use Dacastro4\LaravelGmail\LaravelGmailClass;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+
+class LaravelGmailClassTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'gmail.client_secret' => 'secret',
+            'gmail.client_id' => 'client',
+            'gmail.redirect_url' => '/',
+            'gmail.credentials_file_name' => 'test-token',
+            'gmail.allow_json_encrypt' => false,
+            'gmail.allow_multiple_credentials' => false,
+        ]);
+    }
+
+    /** @test */
+    public function user_method_returns_email_from_saved_token()
+    {
+        Storage::fake('local');
+        $client = new LaravelGmailClass($this->app['config']);
+
+        $ref = new \ReflectionProperty(LaravelGmailClass::class, 'emailAddress');
+        $ref->setAccessible(true);
+        $ref->setValue($client, 'user@example.com');
+
+        $client->saveAccessToken([
+            'access_token' => 'token',
+            'refresh_token' => 'refresh',
+        ]);
+
+        $this->assertEquals('user@example.com', $client->user());
+    }
+
+    /** @test */
+    public function set_user_id_updates_property()
+    {
+        $client = new LaravelGmailClass($this->app['config']);
+        $returned = $client->setUserId('abc123');
+
+        $this->assertSame($client, $returned);
+        $this->assertEquals('abc123', $client->getUserId());
+    }
+
+    /** @test */
+    public function redirect_returns_redirect_response_to_auth_url()
+    {
+        $client = Mockery::mock(LaravelGmailClass::class.'[getAuthUrl]', [$this->app['config']]);
+        $client->shouldReceive('getAuthUrl')->once()->andReturn('https://example.com/auth');
+
+        $response = $client->redirect();
+
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
+        $this->assertEquals('https://example.com/auth', $response->getTargetUrl());
+    }
+
+    /** @test */
+    public function logout_revokes_and_deletes_token()
+    {
+        $client = Mockery::mock(LaravelGmailClass::class.'[revokeToken,deleteAccessToken]', [$this->app['config']]);
+        $client->shouldReceive('revokeToken')->once();
+        $client->shouldReceive('deleteAccessToken')->once();
+
+        $client->logout();
+    }
+}

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests;
+
+use Dacastro4\LaravelGmail\Services\Message\Mail;
+use Illuminate\Support\Facades\Storage;
+
+class MailTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'gmail.client_secret' => 'secret',
+            'gmail.client_id' => 'client',
+            'gmail.redirect_url' => '/',
+            'gmail.credentials_file_name' => 'test-token',
+            'gmail.allow_json_encrypt' => false,
+            'gmail.allow_multiple_credentials' => false,
+        ]);
+    }
+
+    /** @test */
+    public function get_from_parses_name_and_email()
+    {
+        Storage::fake('local');
+        $mail = new Mail;
+
+        $header = new \Google_Service_Gmail_MessagePartHeader;
+        $header->setName('From');
+        $header->setValue('John Doe <john@example.com>');
+        $payload = new \Google_Service_Gmail_MessagePart;
+        $payload->setHeaders([$header]);
+
+        $ref = new \ReflectionProperty(Mail::class, 'payload');
+        $ref->setAccessible(true);
+        $ref->setValue($mail, $payload);
+
+        $from = $mail->getFrom();
+
+        $this->assertSame('John Doe', $from['name']);
+        $this->assertSame('john@example.com', $from['email']);
+        $this->assertSame('john@example.com', $mail->getFromEmail());
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering token storage and user id retrieval in GmailConnection
- add test verifying Mail parses From header correctly

## Testing
- `./vendor/bin/pint --test tests/GmailConnectionTest.php tests/MailTest.php`
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_b_689f92f199bc832eb7024c834940b846