### PR TITLE
Add initial database file and tests for user retrieval

### DIFF
--- a/tests/LaravelGmailTest.php
+++ b/tests/LaravelGmailTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Dacastro4\LaravelGmail\LaravelGmailClass;
 use Dacastro4\LaravelGmail\Services\Message\Mail;
 use Illuminate\Container\Container;
 use Illuminate\Mail\Markdown;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class LaravelGmailTest extends TestCase
@@ -38,5 +40,55 @@ class LaravelGmailTest extends TestCase
         $this->assertCount(2, $formatted);
         $this->assertEquals(['name' => 'Alice', 'email' => 'alice@example.com'], $formatted[0]);
         $this->assertEquals(['name' => 'Bob', 'email' => 'bob@example.com'], $formatted[1]);
+    }
+
+    /** @test */
+    public function test_user_returns_email_from_token_file()
+    {
+        Storage::fake('local');
+
+        config([
+            'gmail.client_secret' => 'secret',
+            'gmail.client_id' => 'client',
+            'gmail.redirect_url' => '/',
+            'gmail.credentials_file_name' => 'test-token',
+            'gmail.allow_json_encrypt' => false,
+            'gmail.allow_multiple_credentials' => false,
+        ]);
+
+        Storage::disk('local')->put(
+            'gmail/tokens/test-token.json',
+            json_encode([
+                'access_token' => 'token',
+                'refresh_token' => 'refresh',
+                'email' => 'foo@example.com',
+                'expires_in' => 3600,
+                'created' => time(),
+            ])
+        );
+
+        $client = new LaravelGmailClass($this->app['config']);
+
+        $this->assertEquals('foo@example.com', $client->user());
+    }
+
+    /** @test */
+    public function test_set_user_id_updates_property()
+    {
+        Storage::fake('local');
+
+        config([
+            'gmail.client_secret' => 'secret',
+            'gmail.client_id' => 'client',
+            'gmail.redirect_url' => '/',
+            'gmail.credentials_file_name' => 'test-token',
+            'gmail.allow_json_encrypt' => false,
+            'gmail.allow_multiple_credentials' => false,
+        ]);
+
+        $client = new LaravelGmailClass($this->app['config']);
+        $client->setUserId('user-123');
+
+        $this->assertEquals('user-123', $client->getUserId());
     }
 }


### PR DESCRIPTION
## Summary
- add placeholder SQLite database for upcoming work
- test that user email comes from stored token
- test updating user ID on Gmail client

## Testing
- `./vendor/bin/phpunit -c phpunit.xml tests`
- `./vendor/bin/pint tests/LaravelGmailTest.php`


------
https://chatgpt.com/codex/tasks/task_b_689f77f86b2c832eb292a8f5f22cd14a