### PR TITLE
Add snippet getter to Mail service

### DIFF
--- a/src/Services/Message/Mail.php
+++ b/src/Services/Message/Mail.php
@@ -43,6 +43,8 @@ class Mail extends GmailConnection
 
     protected ?Google_Service_Gmail_MessagePart $payload = null;
 
+    protected ?string $snippet = null;
+
     protected ?Collection $parts = null;
 
     protected Google_Service_Gmail $service;
@@ -87,6 +89,7 @@ class Mail extends GmailConnection
         $this->threadId = $message->getThreadId();
         $this->historyId = $message->getHistoryId();
         $this->payload = $message->getPayload();
+        $this->snippet = $message->getSnippet();
         if ($this->payload) {
             $this->parts = collect($this->payload->getParts());
         }
@@ -172,6 +175,14 @@ class Mail extends GmailConnection
         $replyTo = $this->getHeader('Reply-To');
 
         return $this->getFrom($replyTo ? $replyTo : $this->getHeader('From'));
+    }
+
+    /**
+     * Returns the snippet from the email
+     */
+    public function getSnippet(): ?string
+    {
+        return $this->snippet;
     }
 
     /**

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Dacastro4\LaravelGmail\Contracts\TokenRepository;
 use Dacastro4\LaravelGmail\Services\Message\Mail;
 use Illuminate\Support\Facades\Storage;
 
@@ -25,7 +26,23 @@ class MailTest extends TestCase
     public function get_from_parses_name_and_email()
     {
         Storage::fake('local');
-        $mail = new Mail;
+        $tokenRepo = new class implements TokenRepository
+        {
+            public function tokenExists(string $fileName): bool
+            {
+                return false;
+            }
+
+            public function getToken(string $fileName, bool $allowJsonEncrypt): array
+            {
+                return [];
+            }
+
+            public function storeToken(string $fileName, array $config, bool $allowJsonEncrypt): void {}
+
+            public function deleteToken(string $fileName, bool $allowJsonEncrypt): void {}
+        };
+        $mail = new Mail($tokenRepo);
 
         $header = new \Google_Service_Gmail_MessagePartHeader;
         $header->setName('From');
@@ -42,5 +59,34 @@ class MailTest extends TestCase
         $this->assertSame('John Doe', $from['name']);
         $this->assertSame('john@example.com', $from['email']);
         $this->assertSame('john@example.com', $mail->getFromEmail());
+    }
+
+    /** @test */
+    public function it_returns_the_snippet()
+    {
+        Storage::fake('local');
+        $tokenRepo = new class implements TokenRepository
+        {
+            public function tokenExists(string $fileName): bool
+            {
+                return false;
+            }
+
+            public function getToken(string $fileName, bool $allowJsonEncrypt): array
+            {
+                return [];
+            }
+
+            public function storeToken(string $fileName, array $config, bool $allowJsonEncrypt): void {}
+
+            public function deleteToken(string $fileName, bool $allowJsonEncrypt): void {}
+        };
+        $mail = new Mail($tokenRepo);
+
+        $ref = new \ReflectionProperty(Mail::class, 'snippet');
+        $ref->setAccessible(true);
+        $ref->setValue($mail, 'This is a snippet');
+
+        $this->assertSame('This is a snippet', $mail->getSnippet());
     }
 }


### PR DESCRIPTION
## Summary
- capture Gmail snippet when setting a message and expose `getSnippet`
- test snippet retrieval from Mail service

## Testing
- `vendor/bin/phpunit tests/MailTest.php`


------
https://chatgpt.com/codex/tasks/task_b_689fb550ae2c832eb6fce272ef088e73